### PR TITLE
textract failure

### DIFF
--- a/zodo/utils.py
+++ b/zodo/utils.py
@@ -251,8 +251,13 @@ def download_supplemental(raw_json):
 def extract_text_from_files(pmcdir):
     supp_files = [x for x in listdir(pmcdir) if x.split(".")[-1] in SUPPLEMENTAL_DATA_FILETYPES]
     logging.debug("Files for extraction in %s : %s", pmcdir, ",".join(supp_files))
-    # For now just extract all text the same way using textract
-    supp_file_contents = {x:str(textract.process(join(pmcdir, x))).replace("\\n", "\n") for x in supp_files}
+    # For now just extract all text the same way using textract (textract may fail)
+    supp_file_contents = {}
+    for suppfile in supp_files:
+        try:
+            supp_file_contents[suppfile] = str(textract.process(join(pmcdir, suppfile))).replace("\\n", "\n")
+        except Exception as e:
+            logging.error("Error in textract: %s", e)
     supp_contents = ""
     for suppfile, content in supp_file_contents.items():
         supp_contents += "\n\n*** " + str(suppfile) + " ***\n" + str(content)


### PR DESCRIPTION
Attempted solution to textract error:
```
Traceback (most recent call last):
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/run.py", line 191, in <module>
    main()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/run.py", line 184, in main
    extract_genbank_loih(args)
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/run.py", line 83, in extract_genbank_loih
    gb_req.process_genbank_ids()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/GenBank.py", line 91, in process_genbank_ids
    self.extract_pubmed_records()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/GenBank.py", line 451, in extract_pubmed_records
    pubmed_req.get_pubmed_texts()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/PubMed.py", line 76, in get_pubmed_texts
    raw_text = extract_text_from_files(SUPPLEMENTAL_DATA_DIR+pmid)
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/utils.py", line 255, in extract_text_from_files
    supp_file_contents = {x:str(textract.process(join(pmcdir, x))).replace("\\n", "\n") for x in supp_files}
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/utils.py", line 255, in <dictcomp>
    supp_file_contents = {x:str(textract.process(join(pmcdir, x))).replace("\\n", "\n") for x in supp_files}
  File "/home/blake_inderski/.local/lib/python3.7/site-packages/textract/parsers/__init__.py", line 77, in process
    return parser.process(filename, encoding, **kwargs)
  File "/home/blake_inderski/.local/lib/python3.7/site-packages/textract/parsers/utils.py", line 47, in process
    unicode_string = self.decode(byte_string)
  File "/home/blake_inderski/.local/lib/python3.7/site-packages/textract/parsers/utils.py", line 65, in decode
    return text.decode(result['encoding'])
  File "/usr/lib/python3.7/encodings/cp1254.py", line 15, in decode
    return codecs.charmap_decode(input,errors,decoding_table)
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 15031: character maps to <undefined>
```

New error:
```
Traceback (most recent call last):
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/run.py", line 191, in <module>
    main()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/run.py", line 184, in main
    extract_genbank_loih(args)
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/run.py", line 83, in extract_genbank_loih
    gb_req.process_genbank_ids()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/GenBank.py", line 91, in process_genbank_ids
    self.extract_pubmed_records()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/GenBank.py", line 451, in extract_pubmed_records
    pubmed_req.get_pubmed_texts()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/PubMed.py", line 85, in get_pubmed_texts
    pubmed_record.extract_entities()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/PubMed.py", line 132, in extract_entities
    self.spans, self.raw_text = detect(doc_bioc, bioc_json=True)
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/ner/ner_utils.py", line 223, in detect
    doc_sents, doc_text, spans = tokenize_bioc(text)
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/ner/ner_utils.py", line 310, in tokenize_bioc
    valid_sections = PMCOA_TYPES if doc_bioc["source"] == "PMC" else PM_TYPES
KeyError: 'source'
```