### PR TITLE
control character error in json.loads()

### DIFF
--- a/zodo/GenBank.py
+++ b/zodo/GenBank.py
@@ -368,7 +368,7 @@ class GenBankRequest(object):
             url = GB_PUBMED_LINK_URL.replace("IDPH", "&id=".join(batch_accessions))
             resp = http_get_query(url, timeout=20, retries=2)
             if resp and resp.text:
-                jsonobj = json.loads(resp.text)
+                jsonobj = json.loads(resp.text, strict=False)
                 if "linksets" in jsonobj:
                     for linkset in jsonobj["linksets"]:
                         if "linksetdbs" in linkset:
@@ -388,7 +388,7 @@ class GenBankRequest(object):
             url = GB_PMC_LINK_URL.replace("IDPH", "&id=".join(batch_accessions))
             resp = http_get_query(url, timeout=20, retries=2)
             if resp and resp.text:
-                jsonobj = json.loads(resp.text)
+                jsonobj = json.loads(resp.text, strict=False)
                 if "linksets" in jsonobj:
                     for linkset in jsonobj["linksets"]:
                         if "linksetdbs" in linkset:
@@ -410,7 +410,7 @@ class GenBankRequest(object):
             url = PM_PMC_LINK_URL.replace("IDSPH", ",".join(pmcids))
             resp = http_get_query(url, timeout=20, retries=3)
             if resp and resp.text:
-                jsonobj = json.loads(resp.text)
+                jsonobj = json.loads(resp.text, strict=False)
                 if "records" in jsonobj:
                     for record in jsonobj["records"]:
                         # we need an additional check as sometimes the key pmid does't exist


### PR DESCRIPTION
Attempted to solve json.load() error (occurred in 6/153 files containing 500 genbank accessions each):

```
Traceback (most recent call last):
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/run.py", line 191, in <module>
    main()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/run.py", line 184, in main
    extract_genbank_loih(args)
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/run.py", line 83, in extract_genbank_loih
    gb_req.process_genbank_ids()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/GenBank.py", line 84, in process_genbank_ids
    self.extract_gb_objects()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/GenBank.py", line 189, in extract_gb_objects
    self.extract_pubmed_links()
  File "/mnt/c/Users/Blake Inderski/Documents/geoboost2-master/zodo/GenBank.py", line 391, in extract_pubmed_links
    jsonobj = json.loads(resp.text)
  File "/usr/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.7/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Invalid control character at: line 1 column 3208 (char 3207)
```

Unknown if the solution is necessary. Re-ran same files that triggered initial errors and they were processed successfully without change.